### PR TITLE
Revert to K&R C in sudo.c

### DIFF
--- a/bsd/sudo/sudo.c
+++ b/bsd/sudo/sudo.c
@@ -25,12 +25,16 @@
 #include <string.h>
 #include <errno.h>
 
-static void usage(const char *progname) {
+static void usage(progname) 
+char *progname;
+{
     fprintf(stderr, "Usage: %s [-u <user>] <command> [args...]\n", progname);
     exit(1);
 }
 
-int main(int argc, char *argv[])
+int main(argc, argv[])
+int argc;
+char *argv[];
 {
     struct passwd *pwd_cur;   /* user invoking sudo */
     struct passwd *pwd_tgt;   /* target user (defaults to root) */


### PR DESCRIPTION
This modifies the code in sudo.c to use K&R declaration style, allowing the program to be compiled on older 2.11 BSC cc versions.

Tested on my PiDP-11 and Dave's PDP-11/83.