### PR TITLE
Added mirrored katakana softfont to Matrix screensaver.

### DIFF
--- a/bsd/screensavers/matrix.c
+++ b/bsd/screensavers/matrix.c
@@ -23,6 +23,19 @@
 #define SCREEN_WIDTH 80
 #define SCREEN_HEIGHT 24
 
+
+/*
+** Strings to load a VT220 softfont providing the extra Matrix characters, select it and unselect it.
+** This softfont contains 46 mirrored katakana as ASCII !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMN
+** The real term is a Dynamically Replaceable Character Sets (DRCS) loaded into the terminal's
+** memory using a Down-Line-Loading DRCS (DECDLD) control string. The font is built using Sixels.
+** Font design by Philippe Majerus, January 2025
+*/
+#define LOAD_MATRIX_SOFTFONT "\033P1;1;2{ MMQAyAAA\?/\?\?\?\?@A\?\?;\?ACwGOO\?/\?\?\?B\?\?\?\?;{CCECC[\?/\?@AAA\?\?\?;\?CC{CC\?\?/AAABAAA\?;CC}ScCC\?/\?\?B\?\?@A\?;{CCC}CC\?/@AAA\?@A\?;_gg}gg_\?/\?\?\?B\?\?\?\?;{CCCCMO\?/\?@AAA\?\?\?;CC{CCMO\?/\?\?\?@AA\?\?;{CCCCCC\?/BAAAAAA\?;C}CCC]C\?/\?\?@AAA\?\?;]_\?\?SSS\?/\?\?@AAAA\?;EIqaAAA\?/A@\?\?@AA\?;KSCCC}C\?/AAAAA@\?\?;Mo\?\?\?WE\?/\?\?@AAAA\?;{csSCMO\?/\?@AAAA\?\?;OQQ{SSO\?/\?\?\?@A\?\?\?;]_\?M\?\?M\?/\?\?@AAAA\?;GIIyIIG\?/\?\?\?@A\?\?\?;OOGG}\?\?\?/\?\?\?\?B\?\?\?;GGG}GGG\?/\?\?\?@AA\?\?;\?CCCCC\?\?/AAAAAAA\?;MQaQAAA\?/A@\?@AA\?\?;CkSecCC\?/@\?\?B\?@@\?;Mo\?\?\?\?\?\?/\?\?@@AAA\?;\?wC\?[_\?\?/B\?\?\?\?@A\?;CCCGGG}\?/AAAAAA@\?;]aAAAAA\?/\?\?@AAA\?\?;\?_OGCGO\?/@\?\?\?\?\?\?\?;CsC}CsC\?/@\?\?BA\?@\?;EIQaaQA\?/\?\?A@\?\?\?\?;CSQIII\?\?/AAA@@@@\?;\?o\?EW_\?\?/B@@AABA\?;MO_OG\?\?\?/A@\?@AAA\?;OQQQ}QO\?/AAAA@\?\?\?;WgGG}GG\?/\?\?@\?B\?\?\?;\?\?{CCC\?\?/AABAAAA\?;}QQQQQQ\?/BAAAAAA\?;WiIIIIG\?/\?\?@AAA\?\?;}\?\?\?\?\?]\?/\?@AAAA\?\?;_\?}\?\?}\?\?/\?@B\?\?@A\?;O_\?\?\?\?}\?/\?\?@@AAB\?;}AAAAA}\?/BAAAAAB\?;]aAAAAM\?/\?\?@AAA\?\?;]iIIIII\?/\?\?@AAA\?\?;]_\?\?CCC\?/\?\?@AAAA\?\033\\"
+#define SELECT_MATRIX_SOFTFONT "\033( M"
+#define UNSELECT_SOFTFONT "\033(B"
+
+
 /* Structure to represent a trail */
 struct Trail {
     int column;      /* Column where the trail is active */
@@ -85,9 +98,22 @@ void update_trails()
             if (trails[i].rows_drawn < trails[i].length) 
             {
                 printf("\033[1;%dH", trails[i].column + 1);
-                c = '!' + (rand() % 94);
-                putchar(c);
-
+                c = (rand() % (94+46));
+                if (c < 94)
+                {
+                    // Normal ASCII character
+                    c += '!';
+                    putchar(c);
+                }
+                else
+                {
+                    // Mirrored Katakana character
+                    c = c - 94 + '!';
+                    printf(SELECT_MATRIX_SOFTFONT);
+                    putchar(c);
+                    printf(UNSELECT_SOFTFONT);
+                }
+                
                 /* Increment the number of rows drawn */
                 trails[i].rows_drawn++;
             }
@@ -119,6 +145,9 @@ int main()
 
     /* Set scrolling region to full screen */
     printf("\033[1;24r");
+
+    /* Load Matrix softfont */
+    printf(LOAD_MATRIX_SOFTFONT);
 
     /* Clear screen */
     printf("\033[2J");


### PR DESCRIPTION
This commit adds a VT220 softfont (DRCS using DECDLD) with the 46 mirrored katakana characters, and extends the matrix screensaver to also use those in the digital rain.

I don't have a VT220 to test it, but it works on Windows Terminal which emulates VT220 softfonts as part of its Sixels support.
