### PR TITLE
Change HTTP response from 403 to 404 on stat error

### DIFF
--- a/bsd/httpd/httpd.c
+++ b/bsd/httpd/httpd.c
@@ -53,7 +53,7 @@ struct stat *st;
     if (stat(path, st) != 0) {
         if (errno & (ENOENT | ENOTDIR | EINVAL | ENAMETOOLONG)) {
             fprintf(htlog, "404 %s\n", strerror(errno));
-            printf("%s\r\n", HTTP_403);
+            printf("%s\r\n", HTTP_404);
         } else if (errno & EACCES) {
             fprintf(htlog, "403 %s\n", strerror(errno));
             printf("%s\r\n", HTTP_403);


### PR DESCRIPTION
This pull request makes a small but important fix to the HTTP status code returned when a requested file is not found. The change ensures that the server responds with the correct HTTP 404 status code instead of 403 in this situation.

* Updated the response in `bsd/httpd/httpd.c` to print `HTTP_404` instead of `HTTP_403` when a file is not found, ensuring proper HTTP status reporting.